### PR TITLE
Bump GraalVM

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -3,6 +3,14 @@ name: release-build
 on:
   release:
     types: [created]
+  push:
+    branches:
+    - master
+    - 'feature/**'
+  pull_request:
+    branches:
+    - master
+    - 'feature/**'
 
 jobs:
   build:
@@ -14,7 +22,7 @@ jobs:
     - name: Set up GraalVM
       uses: DeLaGuardo/setup-graalvm@master
       with:
-        graalvm-version: '21.3.0.java11'
+        graalvm-version: '22.2.0.java11'
     - name: install native-image
       run: gu install native-image
     - name: Grant execute permission for mvnw


### PR DESCRIPTION
- Bump GraalVM to 22.2.0
- Make native build part of pull request workflow