### PR TITLE
Remove explicit version of nimbus-jose

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
     <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
-      <version>10.8</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
Remove explicit version of nimbus-jose, instead relying on version from quarkus bom